### PR TITLE
Switched from liftP to R.andThen

### DIFF
--- a/nextapp/apollo/model/index.ts
+++ b/nextapp/apollo/model/index.ts
@@ -27,7 +27,7 @@ function hasPermission(permission: string, claims?: Claims): boolean {
   return claims?.permissions.includes(permission) ?? false;
 }
 
-export function validateOrSucceed<T, R extends T>(
+export function validateOrSucceed<T, R extends T = Required<T>>(
   fn: (t1: T) => { [key: string]: any },
 ) {
   return (arg: T) => {

--- a/nextapp/utils/fp.spec.ts
+++ b/nextapp/utils/fp.spec.ts
@@ -1,20 +1,4 @@
-import { liftP, validateOrFail } from "./fp";
-
-describe("liftP", () => {
-  describe("addP", () => {
-    let addP: (x: Promise<number>, y: Promise<number>) => Promise<number>;
-    beforeEach(() => {
-      const add = (x: number, y: number) => x + y;
-      addP = liftP(add);
-    });
-
-    it("should add 2 promises", async () => {
-      const actual = await addP(Promise.resolve(2), Promise.resolve(3));
-      const expected = 5;
-      expect(actual).toEqual(expected);
-    });
-  });
-});
+import { validateOrFail } from "./fp";
 
 describe("validateOrFail", () => {
   describe("validateBoolean", () => {

--- a/nextapp/utils/fp.ts
+++ b/nextapp/utils/fp.ts
@@ -1,18 +1,3 @@
-export function liftP<R>(fn: () => R): () => Promise<R>;
-export function liftP<R, T1>(
-  fn: (v1: T1) => R,
-): (v1: Promise<T1>) => Promise<R>;
-export function liftP<R, T1, T2>(
-  fn: (v1: T1, v2: T2) => R,
-): (v1: Promise<T1>, v2: Promise<T2>) => Promise<R>;
-export function liftP<R, T>(
-  fn: (...args: ReadonlyArray<T>) => R,
-): (...args: ReadonlyArray<Promise<T>>) => Promise<R> {
-  return (...args: ReadonlyArray<Promise<T>>) => {
-    return Promise.all(args).then((x) => fn.apply(null, x));
-  };
-}
-
 export function validateOrFail<T1>(
   validate: (v1: T1) => boolean,
   error: (v1: T1) => Error,


### PR DESCRIPTION
* Now we can use R.pipe instead of R.pipeP which is deprecated. Also
cleans up types.